### PR TITLE
chore: fix go version to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/bradfitz/go-tool-cache
 
-go 1.19
+go 1.20


### PR DESCRIPTION
The [stirngs.CutPrefix](https://pkg.go.dev/strings#CutPrefix) was introduced in go `1.20`, we should use `1.20`in go mod also.

Regards