### PR TITLE
gocached: add size histogram and more labels to latency histograms

### DIFF
--- a/gocached/gocached.go
+++ b/gocached/gocached.go
@@ -379,14 +379,24 @@ func (srv *Server) start() error {
 	reqLatencyBuckets := []float64{0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2}
 	srv.getDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "gocached_get_duration_seconds",
-		Help:    "wall time of each cache get request, labeled by outcome: get (hit), miss (404), or error",
+		Help:    "wall time of each cache get request, labeled by storage path: disk, inline, none (HEAD request), or error; and type: get (hit), miss (404), or error",
 		Buckets: reqLatencyBuckets,
-	}, []string{"type"})
+	}, []string{"storage", "type"})
 	srv.putDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "gocached_put_duration_seconds",
-		Help:    "wall time of each cache put request, labeled by storage path: disk, inline, or error",
+		Help:    "wall time of each cache put request, labeled by storage path: disk, inline, or error; and type: put (success), dup, or error",
 		Buckets: reqLatencyBuckets,
-	}, []string{"storage"})
+	}, []string{"storage", "type"})
+	blobSizeBuckets := []float64{1}
+	for i := 6; i <= 30; i += 2 {
+		bucket := 1 << i
+		blobSizeBuckets = append(blobSizeBuckets, float64(bucket))
+	}
+	srv.blobSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "gocached_blob_size_bytes",
+		Help:    "object size in bytes transmitted on the wire (whether compressed or uncompressed) for successful GETs and PUTs, labeled by storage: disk, inline, or error; and type: get, put, or dup",
+		Buckets: blobSizeBuckets,
+	}, []string{"storage", "type"})
 
 	// Fill the namespace ID cache.
 	rows, err := srv.db.Query("SELECT NamespaceID, Namespace FROM Namespaces")
@@ -413,7 +423,7 @@ func (srv *Server) start() error {
 		collectors.NewBuildInfoCollector(),
 	)
 	srv.registerMetrics(reg)
-	reg.MustRegister(srv.shardScanDuration, srv.getDuration, srv.putDuration)
+	reg.MustRegister(srv.shardScanDuration, srv.getDuration, srv.putDuration, srv.blobSize)
 
 	// Per-scrape gauges for shard stats loop health. GaugeFunc recomputes on
 	// every Prometheus scrape, so the values stay fresh between scans
@@ -785,12 +795,13 @@ type Server struct {
 	// reflection.
 	shardScanDuration prometheus.Histogram
 
-	// getDuration and putDuration observe the wall time of each /action GET
-	// and PUT request handler, labeled by outcome. getDuration.type is one
-	// of "get" (hit), "miss" (404), or "error". putDuration.storage is one
-	// of "disk", "inline", or "error".
+	// getDuration, putDuration, and blobSize observe the wall time and transfer
+	// size of each /action GET and PUT request handler, labeled by storage and
+	// type. type is one of "get" (hit), "miss" (404), "put", "dup", or "error".
+	// storage is one of "disk", "inline", "none", or "error".
 	getDuration *prometheus.HistogramVec
 	putDuration *prometheus.HistogramVec
+	blobSize    *prometheus.HistogramVec
 
 	// Metrics. Exported fields for reflection, but within a private struct
 	// field to control the gocached Server API surface.
@@ -1066,11 +1077,12 @@ func (srv *Server) handleGetAction(w http.ResponseWriter, r *http.Request, stats
 	defer srv.m.ActiveGets.Add(-1)
 
 	start := srv.now()
+	storage := "error"
 	result := "error"
 	defer func() {
 		d := srv.now().Sub(start)
 		stats.GetNanos += d.Nanoseconds()
-		srv.getDuration.WithLabelValues(result).Observe(d.Seconds())
+		srv.getDuration.WithLabelValues(storage, result).Observe(d.Seconds())
 	}()
 	stats.Gets++
 	ctx := r.Context()
@@ -1111,6 +1123,7 @@ func (srv *Server) handleGetAction(w http.ResponseWriter, r *http.Request, stats
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			result = "miss"
+			storage = "none"
 			http.Error(w, "not found", http.StatusNotFound)
 			return
 		}
@@ -1147,6 +1160,7 @@ func (srv *Server) handleGetAction(w http.ResponseWriter, r *http.Request, stats
 	}
 
 	if r.Method == "HEAD" || (storedSize == 0 && uncompressedSize == 0) {
+		storage = "none"
 		return
 	}
 
@@ -1154,6 +1168,8 @@ func (srv *Server) handleGetAction(w http.ResponseWriter, r *http.Request, stats
 		// For small outputs stored inline in the database, we can return them directly.
 		stats.GetHitsInline++
 		stats.GetBytes += storedSize
+		storage = "inline"
+		srv.blobSize.WithLabelValues(storage, result).Observe(float64(storedSize))
 		io.WriteString(w, smallData.String)
 		return
 	}
@@ -1175,17 +1191,21 @@ func (srv *Server) handleGetAction(w http.ResponseWriter, r *http.Request, stats
 		// will eventually remove the Action row from the DB
 		// after identifying it as a dangling reference.
 		result = "miss"
+		storage = "none"
 		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
 	defer rc.Close()
+	storage = "disk"
 
 	if isLZ4 && !clientAcceptsLZ4 {
 		// Client doesn't accept lz4; decompress on the fly.
 		stats.GetBytes += uncompressedSize
+		srv.blobSize.WithLabelValues(storage, result).Observe(float64(uncompressedSize))
 		io.Copy(w, lz4.NewReader(rc))
 	} else {
 		stats.GetBytes += storedSize
+		srv.blobSize.WithLabelValues(storage, result).Observe(float64(storedSize))
 		io.Copy(w, rc)
 	}
 }
@@ -1331,10 +1351,11 @@ func (s *Server) handlePut(w http.ResponseWriter, r *http.Request, stats *stats,
 
 	start := s.now()
 	storage := "error"
+	result := "error"
 	defer func() {
 		d := s.now().Sub(start)
 		stats.PutsNanos += d.Nanoseconds()
-		s.putDuration.WithLabelValues(storage).Observe(d.Seconds())
+		s.putDuration.WithLabelValues(storage, result).Observe(d.Seconds())
 	}()
 
 	if r.Method != "PUT" {
@@ -1434,8 +1455,10 @@ func (s *Server) handlePut(w http.ResponseWriter, r *http.Request, stats *stats,
 
 	if affected == 0 {
 		stats.PutsDup++
+		result = "dup"
 	} else {
 		s.addBlobDelta(sha256hex, +1, +storedSize)
+		result = "put"
 	}
 
 	stats.Puts++
@@ -1446,6 +1469,7 @@ func (s *Server) handlePut(w http.ResponseWriter, r *http.Request, stats *stats,
 	} else {
 		storage = "disk"
 	}
+	s.blobSize.WithLabelValues(storage, result).Observe(float64(r.ContentLength))
 
 	w.WriteHeader(http.StatusNoContent)
 }


### PR DESCRIPTION
```
Adds new gocached_blob_size_bytes histogram metric for tracking
blob sizes as transmitted on the wire.

Adds result label (put, dup, error) to PUTs latency, and storage label
(disk, inline, none, error) to GETs latency.
```