### PR TITLE
gocached, cmd/gocached: add storage tiering and a separate SQLite dir

### DIFF
--- a/cmd/gocached/gocached.go
+++ b/cmd/gocached/gocached.go
@@ -22,6 +22,9 @@ import (
 
 var (
 	dir         = flag.String("cache-dir", "", "cache directory, if empty defaults to <UserCacheDir>/gocached")
+	sqliteDir   = flag.String("sqlite-dir", "", "directory for the SQLite metadata database; if empty, defaults to the cache directory")
+	hotDir      = flag.String("hot-dir", "", "if non-empty, enable storage tiering with this directory as a fast tier (e.g. local NVMe) holding a bounded copy of recently used blobs; the cache directory remains the source of truth")
+	hotCapacity = flag.Int("hot-capacity-gb", 600, "maximum size of the hot tier directory in GiB; only used with --hot-dir")
 	verbose     = flag.Bool("verbose", false, "be verbose")
 	listen      = flag.String("listen", ":31364", "listen address for the build-facing HTTP server")
 	debugListen = flag.String("debug-listen", "", "if non-empty, listen address for the debug HTTP server (pprof, metrics, etc)")
@@ -65,10 +68,21 @@ func main() {
 
 	opts := []gocached.ServerOption{
 		gocached.WithDir(*dir),
+		gocached.WithSQLiteDir(*sqliteDir),
 		gocached.WithVerbose(*verbose),
 		gocached.WithMaxSize(int64(*maxSize) << 30),
 		gocached.WithMaxAge(time.Duration(*maxAge) * 24 * time.Hour),
 		gocached.WithShardPrefixLen(*shardPrefixLen),
+	}
+
+	if *hotDir != "" {
+		if *hotCapacity <= 0 {
+			log.Fatal("--hot-capacity-gb must be positive when --hot-dir is set")
+		}
+		opts = append(opts,
+			gocached.WithHotDir(*hotDir),
+			gocached.WithHotCapacity(int64(*hotCapacity)<<30),
+		)
 	}
 
 	if *jwtIssuer != "" {

--- a/gocached/gocached.go
+++ b/gocached/gocached.go
@@ -329,7 +329,35 @@ func (srv *Server) start() error {
 	if err := os.MkdirAll(srv.dir, 0750); err != nil {
 		return fmt.Errorf("creating cache dir: %w", err)
 	}
-	db, err := openDB(srv.dir)
+	if srv.sqliteDir == "" {
+		srv.sqliteDir = srv.dir
+	} else if err := os.MkdirAll(srv.sqliteDir, 0750); err != nil {
+		return fmt.Errorf("creating sqlite dir: %w", err)
+	}
+	if srv.hotDir != "" {
+		if srv.hotDir == srv.dir {
+			return fmt.Errorf("hot dir %q must differ from cache dir", srv.hotDir)
+		}
+		if srv.hotCap <= 0 {
+			return fmt.Errorf("hot capacity must be positive when hot dir is set")
+		}
+		if err := os.MkdirAll(srv.hotDir, 0750); err != nil {
+			return fmt.Errorf("creating hot dir: %w", err)
+		}
+		srv.hot = newHotIndex()
+		// Populate the index asynchronously: scanning millions of files can
+		// take a while, and reads can be served from existing hot files right
+		// away. Until the scan completes and marks the index ready, nothing
+		// new is written into the hot tier.
+		go func() {
+			if err := srv.hot.scan(srv.shutdownCtx, srv.hotDir, srv.logf); err != nil {
+				srv.logf("hot tier: scan failed; hot tier writes remain disabled: %v", err)
+				return
+			}
+			srv.evictHotIfOver()
+		}()
+	}
+	db, err := openDB(srv.sqliteDir)
 	if err != nil {
 		return fmt.Errorf("openDB: %w", err)
 	}
@@ -379,7 +407,7 @@ func (srv *Server) start() error {
 	reqLatencyBuckets := []float64{0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2}
 	srv.getDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "gocached_get_duration_seconds",
-		Help:    "wall time of each cache get request, labeled by storage path: disk, inline, none (HEAD request), or error; and type: get (hit), miss (404), or error",
+		Help:    "wall time of each cache get request, labeled by storage path: hot (hot tier disk), disk, inline, none (HEAD request), or error; and type: get (hit), miss (404), or error",
 		Buckets: reqLatencyBuckets,
 	}, []string{"storage", "type"})
 	srv.putDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -394,7 +422,7 @@ func (srv *Server) start() error {
 	}
 	srv.blobSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "gocached_blob_size_bytes",
-		Help:    "object size in bytes transmitted on the wire (whether compressed or uncompressed) for successful GETs and PUTs, labeled by storage: disk, inline, or error; and type: get, put, or dup",
+		Help:    "object size in bytes transmitted on the wire (whether compressed or uncompressed) for successful GETs and PUTs, labeled by storage: hot, disk, inline, or error; and type: get, put, or dup",
 		Buckets: blobSizeBuckets,
 	}, []string{"storage", "type"})
 
@@ -478,6 +506,48 @@ func (srv *Server) start() error {
 			return float64(b)
 		},
 	))
+
+	if srv.hot != nil {
+		reg.MustRegister(prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Name: "gocached_hot_bytes",
+				Help: "bytes currently stored in the hot tier directory; bounded by the configured hot capacity",
+			},
+			func() float64 { return float64(srv.hot.usageBytes()) },
+		))
+		reg.MustRegister(prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Name: "gocached_hot_files",
+				Help: "number of blob files currently stored in the hot tier directory",
+			},
+			func() float64 { return float64(srv.hot.len()) },
+		))
+		reg.MustRegister(prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Name: "gocached_hot_ready",
+				Help: "1 once the hot tier startup scan has completed and new blobs may be written into the hot tier, else 0; alert if this stays 0 well past startup",
+			},
+			func() float64 {
+				if srv.hot.ready.Load() {
+					return 1
+				}
+				return 0
+			},
+		))
+		reg.MustRegister(prometheus.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Name: "gocached_hot_scan_running_seconds",
+				Help: "how long the hot tier startup scan has currently been running, in seconds; 0 when the scan is not running",
+			},
+			func() float64 {
+				ns := srv.hot.scanStart.Load()
+				if ns == 0 {
+					return 0
+				}
+				return time.Since(time.Unix(0, ns)).Seconds()
+			},
+		))
+	}
 
 	srv.metricsHandler = promhttp.HandlerFor(reg, promhttp.HandlerOpts{
 		ErrorLog: log.Default(),
@@ -568,6 +638,34 @@ func WithShutdownCtx(ctx context.Context) ServerOption {
 func WithDir(dir string) ServerOption {
 	return func(srv *Server) {
 		srv.dir = dir
+	}
+}
+
+// WithSQLiteDir sets the directory where the server stores its SQLite
+// database. Defaults to the blob directory (see [WithDir]).
+func WithSQLiteDir(dir string) ServerOption {
+	return func(srv *Server) {
+		srv.sqliteDir = dir
+	}
+}
+
+// WithHotDir enables storage tiering, using dir as a fast storage tier (e.g.
+// local NVMe) holding a bounded copy of recently used blobs. The main blob
+// directory (see [WithDir]) remains the source of truth containing all blobs;
+// files in the hot directory can be deleted at any time. If set,
+// [WithHotCapacity] must also be set. Defaults to empty, meaning no tiering.
+func WithHotDir(dir string) ServerOption {
+	return func(srv *Server) {
+		srv.hotDir = dir
+	}
+}
+
+// WithHotCapacity sets the maximum number of bytes stored in the hot tier
+// directory (see [WithHotDir]). When usage exceeds this capacity, the least
+// recently used hot files are deleted.
+func WithHotCapacity(bytes int64) ServerOption {
+	return func(srv *Server) {
+		srv.hotCap = bytes
 	}
 }
 
@@ -718,7 +816,11 @@ func (srv *Server) Close() error {
 // valid instance.
 type Server struct {
 	db             *sql.DB
-	dir            string // for SQLite DB + large blobs
+	dir            string // for large blobs (and the SQLite DB, unless sqliteDir is set)
+	sqliteDir      string // for the SQLite DB; if empty, defaults to dir
+	hotDir         string // if non-empty, fast storage tier for a bounded copy of hot blobs
+	hotCap         int64  // maximum bytes in hotDir; must be positive if hotDir is set
+	hot            *hotIndex
 	verbose        bool
 	logf           logger.Logf
 	clock          func() time.Time // if non-nil, alternate time.Now for testing
@@ -830,6 +932,15 @@ type Server struct {
 
 		SQLiteDataBytes expvar.Int `type:"gauge" name:"sqlite_data_bytes" help:"size in bytes of the SQLite main database file on disk"`
 		SQLiteWALBytes  expvar.Int `type:"gauge" name:"sqlite_wal_bytes" help:"size in bytes of the SQLite WAL file on disk; should stay bounded near walJournalSizeLimit"`
+
+		HotHits          expvar.Int `type:"counter" name:"hot_hits" help:"GETs served from the hot tier"`
+		HotMisses        expvar.Int `type:"counter" name:"hot_misses" help:"GETs that were not served from the hot tier"`
+		HotReadErrs      expvar.Int `type:"counter" name:"hot_read_errs" help:"hot tier opens that failed for a reason other than the file not existing; reads fall back to the main blob directory"`
+		HotPromotions    expvar.Int `type:"counter" name:"hot_promotions" help:"blobs copied into the hot tier after a hot tier miss"`
+		HotPromotionErrs expvar.Int `type:"counter" name:"hot_promotion_errs" help:"failed attempts to copy a blob into the hot tier"`
+		HotWriteErrs     expvar.Int `type:"counter" name:"hot_write_errs" help:"failed hot tier writes during PUT; the PUT itself still succeeds"`
+		HotEvicted       expvar.Int `type:"counter" name:"hot_evicted" help:"files evicted from the hot tier to stay under its capacity"`
+		HotEvictedBytes  expvar.Int `type:"counter" name:"hot_evicted_bytes" help:"bytes reclaimed by evicting files from the hot tier"`
 	}
 }
 
@@ -1177,7 +1288,7 @@ func (srv *Server) handleGetAction(w http.ResponseWriter, r *http.Request, stats
 	// Otherwise, for large objects that we know about, we can try to get them
 	// from our local disk or a peer.
 
-	rc, err := srv.getObjectFromDiskOrPeer(ctx, sha256hex, isLZ4)
+	rc, fromHot, err := srv.getObjectFromDiskOrPeer(ctx, sha256hex, isLZ4)
 	if err != nil {
 		srv.logf("Get object error: %v", err)
 		result = "error"
@@ -1197,6 +1308,9 @@ func (srv *Server) handleGetAction(w http.ResponseWriter, r *http.Request, stats
 	}
 	defer rc.Close()
 	storage = "disk"
+	if fromHot {
+		storage = "hot"
+	}
 
 	if isLZ4 && !clientAcceptsLZ4 {
 		// Client doesn't accept lz4; decompress on the fly.
@@ -1324,25 +1438,152 @@ func (srv *Server) flushAccessTimeBumpsWithErr() (ret error) {
 //
 // If isLZ4 is true, the .lz4 suffixed path is opened; otherwise the plain path.
 //
-// It returns (nil, nil) on miss.
-func (srv *Server) getObjectFromDiskOrPeer(_ context.Context, sha256hex string, isLZ4 bool) (rc io.ReadCloser, err error) {
+// With tiering enabled, the hot tier is consulted first; fromHot reports
+// whether the returned reader is backed by the hot tier. A hot tier miss that
+// hits the main directory kicks off an asynchronous promotion into the hot
+// tier.
+//
+// It returns (nil, false, nil) on miss.
+func (srv *Server) getObjectFromDiskOrPeer(_ context.Context, sha256hex string, isLZ4 bool) (rc io.ReadCloser, fromHot bool, err error) {
 	if len(sha256hex) != sha256.Size*2 {
-		return nil, fmt.Errorf("invalid sha256hex %q", sha256hex)
+		return nil, false, fmt.Errorf("invalid sha256hex %q", sha256hex)
 	}
-	diskPath := filepath.Join(srv.dir, sha256hex[:2], sha256hex)
+	name := sha256hex
 	if isLZ4 {
-		diskPath += ".lz4"
+		name += ".lz4"
 	}
+	if srv.hot != nil {
+		f, err := os.Open(srv.hotFilepath(name))
+		if err == nil {
+			srv.hot.touch(name)
+			srv.m.HotHits.Add(1)
+			return f, true, nil
+		}
+		srv.m.HotMisses.Add(1)
+		if !os.IsNotExist(err) {
+			srv.m.HotReadErrs.Add(1)
+			srv.logf("hot tier: opening %v: %v", name, err)
+		}
+	}
+	diskPath := filepath.Join(srv.dir, sha256hex[:2], name)
 	f, err := os.Open(diskPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// TODO(bradfitz): search peers, S3, etc.
-			// For now, just return nil, nil on miss.
-			return nil, nil
+			// For now, just return a miss.
+			return nil, false, nil
 		}
-		return nil, err
+		return nil, false, err
 	}
-	return f, nil
+	if srv.hot != nil {
+		// The index may still hold an entry if the hot file vanished out from
+		// under us (e.g. a wiped ephemeral disk); drop it so the stale entry
+		// doesn't block re-promotion and usage accounting stays honest.
+		srv.hot.remove(name)
+		if srv.hot.tryStartPromotion(name) {
+			go srv.promoteToHot(name)
+		}
+	}
+	return f, false, nil
+}
+
+// promoteToHot copies the blob file with the given base filename from the
+// main blob directory into the hot tier. It runs in its own goroutine after a
+// hot tier miss; the caller must have registered the promotion via
+// [hotIndex.tryStartPromotion].
+func (srv *Server) promoteToHot(name string) {
+	defer srv.hot.endPromotion(name)
+	if srv.shutdownCtx.Err() != nil {
+		return
+	}
+	size, err := srv.copyToHot(name)
+	if err != nil {
+		srv.logf("hot tier: promoting %v: %v", name, err)
+		srv.m.HotPromotionErrs.Add(1)
+		return
+	}
+	srv.hot.add(name, size)
+	srv.m.HotPromotions.Add(1)
+	srv.evictHotIfOver()
+}
+
+// copyToHot copies the named blob file from the main blob directory to a temp
+// file in the hot dir and atomically renames it into place, returning the
+// file size. The bytes are copied verbatim (in already-compressed form, if
+// applicable), so no re-hashing or re-compression is needed.
+func (srv *Server) copyToHot(name string) (size int64, err error) {
+	src, err := os.Open(filepath.Join(srv.dir, name[:2], name))
+	if err != nil {
+		return 0, err
+	}
+	defer src.Close()
+
+	tf, err := os.CreateTemp(srv.hotDir, fmt.Sprintf("upload-%d-*", srv.now().Unix()))
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		if err != nil {
+			tf.Close()
+			os.Remove(tf.Name())
+		}
+	}()
+
+	size, err = io.Copy(tf, src)
+	if err != nil {
+		return 0, err
+	}
+	if err := tf.Close(); err != nil {
+		return 0, err
+	}
+	target := srv.hotFilepath(name)
+	if err := os.MkdirAll(filepath.Dir(target), 0750); err != nil {
+		return 0, err
+	}
+	if err := os.Rename(tf.Name(), target); err != nil {
+		return 0, err
+	}
+	return size, nil
+}
+
+// hotEvictTargetPct is the percentage of the hot tier capacity that eviction
+// shrinks usage down to once the capacity is exceeded. Evicting slightly past
+// the limit reduces churn from evicting one file at a time on every write.
+const hotEvictTargetPct = 95
+
+// evictHotIfOver deletes the least recently used hot tier files if the hot
+// tier is over its capacity. It's a no-op when tiering is disabled, the
+// startup scan hasn't yet measured usage, or usage is within bounds. Hot
+// files are just copies, so deletion never loses data.
+func (srv *Server) evictHotIfOver() {
+	if srv.hot == nil || !srv.hot.ready.Load() || srv.hot.usageBytes() <= srv.hotCap {
+		return
+	}
+	for _, ent := range srv.hot.evictLRU(srv.hotCap * hotEvictTargetPct / 100) {
+		if err := os.Remove(srv.hotFilepath(ent.name)); err != nil && !os.IsNotExist(err) {
+			srv.logf("hot tier: evicting %v: %v", ent.name, err)
+		}
+		srv.m.HotEvicted.Add(1)
+		srv.m.HotEvictedBytes.Add(ent.size)
+	}
+}
+
+// removeFromHot deletes both possible hot tier files (plain and .lz4) for the
+// given SHA256 hex string and drops them from the hot index. It is called
+// when a blob is evicted from the cache entirely. The files are removed even
+// if the index doesn't know them (e.g. the startup scan hasn't reached them
+// yet). Errors are logged only: hot files are disposable copies, so a
+// leftover is at worst wasted space that eviction later reclaims.
+func (srv *Server) removeFromHot(sha256Hex string) {
+	if srv.hot == nil {
+		return
+	}
+	for _, name := range []string{sha256Hex, sha256Hex + ".lz4"} {
+		srv.hot.remove(name)
+		if err := os.Remove(srv.hotFilepath(name)); err != nil && !os.IsNotExist(err) {
+			srv.logf("hot tier: removing %v: %v", name, err)
+		}
+	}
 }
 
 func (s *Server) handlePut(w http.ResponseWriter, r *http.Request, stats *stats, namespaceID int64) {
@@ -1623,7 +1864,13 @@ func (s *Server) sha256Filepath(hash [sha256.Size]byte) string {
 	return filepath.Join(s.dir, hex[:2], hex)
 }
 
-func (s *Server) writeDiskBlob(size int64, r io.Reader) (diskSize int64, err error) {
+// hotFilepath returns the hot tier path for the given base filename, which is
+// either "<sha256-hex>" or "<sha256-hex>.lz4".
+func (s *Server) hotFilepath(name string) string {
+	return filepath.Join(s.hotDir, name[:2], name)
+}
+
+func (s *Server) writeDiskBlob(size int64, r io.Reader) (diskSize int64, retErr error) {
 	compress := size >= lz4CompressThreshold
 
 	nowUnix := s.now().Unix()
@@ -1632,20 +1879,46 @@ func (s *Server) writeDiskBlob(size int64, r io.Reader) (diskSize int64, err err
 		return 0, err
 	}
 	defer func() {
-		if err == nil {
+		if retErr == nil {
 			return
 		}
 		tf.Close()
 		os.Remove(tf.Name())
 	}()
 
+	// With tiering enabled, tee the identical bytes into a hot tier temp file
+	// as we write the main one. Hot tier failures never fail the PUT: the main
+	// blob directory is the source of truth, and a later GET re-promotes.
+	// Until the startup scan has the hot tier's usage, skip the hot copy
+	// rather than grow the tier past its unknown budget.
+	var hotName string // base filename of the blob's target; set once the hash is known
+	var fileDst io.Writer = tf
+	if s.hot != nil && s.hot.ready.Load() {
+		htf, herr := os.CreateTemp(s.hotDir, fmt.Sprintf("upload-%d-*", nowUnix))
+		if herr != nil {
+			s.logf("hot tier: creating temp file: %v", herr)
+			s.m.HotWriteErrs.Add(1)
+		} else {
+			// The failsafeWriter swallows mid-stream hot write errors (e.g.
+			// disk full) so the main copy keeps going; finishHotWrite sees the
+			// first such error and cleans up.
+			hotFW := &failsafeWriter{w: htf}
+			fileDst = io.MultiWriter(tf, hotFW)
+			// The deferred call reads the named results, so it installs the
+			// hot copy only when the whole PUT succeeded.
+			defer func() {
+				s.finishHotWrite(htf, hotFW.err, retErr, hotName, diskSize)
+			}()
+		}
+	}
+
 	hasher := sha256.New()
 	lr := io.LimitReader(io.TeeReader(r, hasher), size+1)
 
-	var dst io.Writer = tf
+	dst := fileDst
 	var lzw *lz4.Writer
 	if compress {
-		lzw = lz4.NewWriter(tf)
+		lzw = lz4.NewWriter(fileDst)
 		if err := lzw.Apply(lz4.SizeOption(uint64(size))); err != nil {
 			return 0, err
 		}
@@ -1681,6 +1954,7 @@ func (s *Server) writeDiskBlob(size int64, r io.Reader) (diskSize int64, err err
 	if compress {
 		target += ".lz4"
 	}
+	hotName = filepath.Base(target)
 	if err := os.MkdirAll(filepath.Dir(target), 0750); err != nil {
 		return 0, err
 	}
@@ -1688,6 +1962,36 @@ func (s *Server) writeDiskBlob(size int64, r io.Reader) (diskSize int64, err err
 		return 0, err
 	}
 	return diskSize, nil
+}
+
+// finishHotWrite is deferred by writeDiskBlob when tiering is enabled. If the
+// main blob landed (putErr is writeDiskBlob's result), it installs the hot
+// tier temp file htf that was teed alongside the main copy; on any failure it
+// cleans htf up instead. writeErr is the first error from the failsafeWriter
+// feeding htf, if any. Hot tier failures are logged and counted but never
+// propagated; the hot tier is only a cache of the main blob directory.
+func (s *Server) finishHotWrite(htf *os.File, writeErr, putErr error, name string, size int64) {
+	closeErr := htf.Close()
+	if putErr != nil {
+		// The PUT itself failed; there's no blob to install a hot copy of.
+		os.Remove(htf.Name())
+		return
+	}
+	err := cmp.Or(writeErr, closeErr)
+	if err == nil {
+		target := s.hotFilepath(name)
+		if err = os.MkdirAll(filepath.Dir(target), 0750); err == nil {
+			err = os.Rename(htf.Name(), target)
+		}
+	}
+	if err != nil {
+		s.logf("hot tier: storing blob %v: %v", name, err)
+		s.m.HotWriteErrs.Add(1)
+		os.Remove(htf.Name())
+		return
+	}
+	s.hot.add(name, size)
+	s.evictHotIfOver()
 }
 
 type countAndSize struct {
@@ -2352,6 +2656,7 @@ func (srv *Server) evictOldestActions(ctx context.Context, cutoff int64, maxCoun
 			if err := os.Remove(base); err != nil && !os.IsNotExist(err) {
 				return ret, fmt.Errorf("removing disk file: %w", err)
 			}
+			srv.removeFromHot(sha256Hex)
 		}
 		// Stop once we've freed enough aggregate bytes. For maxAge cleanup
 		// callers pass math.MaxInt64 so this check never triggers.
@@ -2381,6 +2686,7 @@ func (srv *Server) evictOldestActions(ctx context.Context, cutoff int64, maxCoun
 // aggregate from the shard stats loop drives the decision; the eviction itself
 // goes straight at idx_actions_access without consulting the shards.
 func (srv *Server) cleanupTick(ctx context.Context) (countAndSize, error) {
+	srv.evictHotIfOver()
 	var ret countAndSize
 	us := srv.lastUsage.Load()
 	if us == nil {
@@ -2468,7 +2774,7 @@ func (srv *Server) runCheckpointLoop() {
 // dbPath returns the on-disk path of the SQLite main database file.
 // The WAL file is at dbPath() + "-wal".
 func (srv *Server) dbPath() string {
-	return filepath.Join(srv.dir, fmt.Sprintf("gocached-v%d.db", schemaVersion))
+	return filepath.Join(srv.sqliteDir, fmt.Sprintf("gocached-v%d.db", schemaVersion))
 }
 
 // updateDBSizeMetrics re-stats the SQLite files and updates the size gauges.

--- a/gocached/gocached_test.go
+++ b/gocached/gocached_test.go
@@ -279,6 +279,12 @@ func newServerTester(t testing.TB, extraOpts ...ServerOption) *tester {
 	}
 	st.srv = srv
 
+	// The hot tier index is populated by an async startup scan; wait for it
+	// so tests observe deterministic hot tier behavior.
+	if srv.hot != nil {
+		waitFor(t, "hot index scan", srv.hot.ready.Load)
+	}
+
 	st.hs = httptest.NewServer(st.srv)
 	t.Cleanup(func() { st.srv.Close() })
 	t.Cleanup(st.hs.Close)

--- a/gocached/hottier.go
+++ b/gocached/hottier.go
@@ -1,0 +1,251 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package gocached
+
+import (
+	"container/list"
+	"context"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/bradfitz/go-tool-cache/gocached/logger"
+)
+
+// hotIndex is an in-memory LRU index of the blob files resident in the hot
+// tier directory. The hot tier holds a bounded copy of recently used blobs;
+// the main blob directory is the source of truth, so hot files can be
+// deleted at any time without data loss.
+//
+// It starts empty and is populated by an asynchronous startup scan
+// ([hotIndex.scan]), then maintained incrementally as blobs are written,
+// promoted, accessed, and evicted.
+type hotIndex struct {
+	usage atomic.Int64 // sum of sizes of all indexed files, in bytes
+
+	// ready is set once the startup scan has completed. Until then the index
+	// doesn't know the hot dir's usage, so nothing new may be written into
+	// the hot tier (PUT tees and promotions are skipped, and eviction is a
+	// no-op); reads are still served from hot files that already exist.
+	ready atomic.Bool
+
+	// scanStart is the unix-nano time the startup scan began, or 0 when the
+	// scan isn't running. It feeds the gocached_hot_scan_running_seconds
+	// gauge.
+	scanStart atomic.Int64
+
+	mu       sync.Mutex
+	ll       *list.List               // front is most recently used; values are *hotEntry
+	ents     map[string]*list.Element // base filename ("<hex>" or "<hex>.lz4") -> element in ll
+	inflight map[string]struct{}      // base filenames with promotions in progress
+}
+
+// hotEntry describes one file in the hot tier.
+type hotEntry struct {
+	name string // base filename: "<hex>" or "<hex>.lz4"
+	size int64  // file size in bytes
+}
+
+func newHotIndex() *hotIndex {
+	return &hotIndex{
+		ll:       list.New(),
+		ents:     make(map[string]*list.Element),
+		inflight: make(map[string]struct{}),
+	}
+}
+
+// usageBytes reports the total size of all indexed hot files.
+func (h *hotIndex) usageBytes() int64 { return h.usage.Load() }
+
+// len reports the number of indexed hot files.
+func (h *hotIndex) len() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.ents)
+}
+
+// touch marks name as most recently used, if present.
+func (h *hotIndex) touch(name string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if e, ok := h.ents[name]; ok {
+		h.ll.MoveToFront(e)
+	}
+}
+
+// add records that name (of the given size) is now resident in the hot tier,
+// marking it most recently used. Adding an existing name updates its size.
+func (h *hotIndex) add(name string, size int64) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if e, ok := h.ents[name]; ok {
+		ent := e.Value.(*hotEntry)
+		h.usage.Add(size - ent.size)
+		ent.size = size
+		h.ll.MoveToFront(e)
+		return
+	}
+	h.ents[name] = h.ll.PushFront(&hotEntry{name: name, size: size})
+	h.usage.Add(size)
+}
+
+// remove deletes name from the index, reporting its size and whether it was
+// present. It does not remove the file on disk; that's the caller's job.
+func (h *hotIndex) remove(name string) (size int64, ok bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	e, ok := h.ents[name]
+	if !ok {
+		return 0, false
+	}
+	ent := e.Value.(*hotEntry)
+	h.ll.Remove(e)
+	delete(h.ents, name)
+	h.usage.Add(-ent.size)
+	return ent.size, true
+}
+
+// evictLRU removes the least recently used entries from the index until usage
+// is at or below target, returning the removed entries. The caller is
+// responsible for deleting the corresponding files on disk.
+func (h *hotIndex) evictLRU(target int64) []hotEntry {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var evicted []hotEntry
+	for h.usage.Load() > target {
+		e := h.ll.Back()
+		if e == nil {
+			break
+		}
+		ent := e.Value.(*hotEntry)
+		h.ll.Remove(e)
+		delete(h.ents, ent.name)
+		h.usage.Add(-ent.size)
+		evicted = append(evicted, *ent)
+	}
+	return evicted
+}
+
+// tryStartPromotion reports whether the caller should promote name into the
+// hot tier, registering the promotion as in flight if so. It returns false if
+// the startup scan hasn't completed, name is already resident, or a promotion
+// for it is already in flight. Every true return must be paired with a later
+// [hotIndex.endPromotion] call.
+func (h *hotIndex) tryStartPromotion(name string) bool {
+	if !h.ready.Load() {
+		return false
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.ents[name]; ok {
+		return false
+	}
+	if _, ok := h.inflight[name]; ok {
+		return false
+	}
+	h.inflight[name] = struct{}{}
+	return true
+}
+
+// endPromotion unregisters an in-flight promotion started by
+// [hotIndex.tryStartPromotion].
+func (h *hotIndex) endPromotion(name string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.inflight, name)
+}
+
+// staleHotTempAge is how old an "upload-*" temp file in the hot dir must be
+// before the startup scan deletes it as an abandoned leftover from a crash.
+const staleHotTempAge = time.Hour
+
+// failsafeWriter wraps a writer whose failures should not abort the stream
+// feeding it. The first underlying write error is recorded and all subsequent
+// writes are discarded, but Write always reports success so that sibling
+// writers in an [io.MultiWriter] keep receiving bytes.
+type failsafeWriter struct {
+	w   io.Writer
+	err error // first underlying write error, if any
+}
+
+func (fw *failsafeWriter) Write(p []byte) (int, error) {
+	if fw.err == nil {
+		if _, err := fw.w.Write(p); err != nil {
+			fw.err = err
+		}
+	}
+	return len(p), nil
+}
+
+// scan walks dir and populates h with its blob files, ordered by file
+// modification time so the oldest files are evicted first, then marks h
+// ready. Stale "upload-*" temp files left behind by a crash are deleted;
+// fresh ones are skipped, as they may belong to a concurrent writer.
+//
+// It runs asynchronously at server startup; until it completes, nothing new
+// is written into the hot tier (see [hotIndex.ready]), so the directory is
+// stable underneath the walk with one exception: the main cache's size/age
+// eviction keeps running during the scan (only hot tier LRU eviction waits
+// for it), and evicting a blob from the cache also deletes its hot copy via
+// [Server.removeFromHot]. A deleted file the walk already recorded becomes a
+// phantom index entry; that's harmless, as evicting it later is a no-op
+// os.Remove.
+func (h *hotIndex) scan(ctx context.Context, dir string, logf logger.Logf) error {
+	type scanned struct {
+		name  string
+		size  int64
+		mtime time.Time
+	}
+	var files []scanned
+	start := time.Now()
+	h.scanStart.Store(start.UnixNano())
+	defer h.scanStart.Store(0)
+	logf("hot tier: scanning %v ...", dir)
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if d.IsDir() {
+			return nil
+		}
+		fi, err := d.Info()
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if strings.HasPrefix(d.Name(), "upload-") {
+			if time.Since(fi.ModTime()) > staleHotTempAge {
+				if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+					logf("hot tier: removing stale temp %v: %v", path, err)
+				}
+			}
+			return nil
+		}
+		files = append(files, scanned{name: d.Name(), size: fi.Size(), mtime: fi.ModTime()})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	slices.SortFunc(files, func(a, b scanned) int {
+		return a.mtime.Compare(b.mtime)
+	})
+	for _, f := range files {
+		h.add(f.name, f.size)
+	}
+	h.ready.Store(true)
+	logf("hot tier: indexed %d files, %s in %v", len(files), bytesFmt(h.usageBytes()), time.Since(start).Round(time.Millisecond))
+	return nil
+}

--- a/gocached/hottier_test.go
+++ b/gocached/hottier_test.go
@@ -1,0 +1,405 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package gocached
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHotIndex(t *testing.T) {
+	h := newHotIndex()
+	h.add("aa1", 10)
+	h.add("bb2", 20)
+	h.add("cc3", 30)
+	if got, want := h.usageBytes(), int64(60); got != want {
+		t.Errorf("usage = %d, want %d", got, want)
+	}
+	if got, want := h.len(), 3; got != want {
+		t.Errorf("len = %d, want %d", got, want)
+	}
+
+	// Re-adding updates size without duplicating.
+	h.add("bb2", 25)
+	if got, want := h.usageBytes(), int64(65); got != want {
+		t.Errorf("usage after re-add = %d, want %d", got, want)
+	}
+	if got, want := h.len(), 3; got != want {
+		t.Errorf("len after re-add = %d, want %d", got, want)
+	}
+
+	// Recency order is now (most to least recent): bb2, cc3, aa1. Touching
+	// aa1 makes cc3 the least recently used entry.
+	h.touch("aa1")
+	evicted := h.evictLRU(40)
+	var names []string
+	for _, e := range evicted {
+		names = append(names, e.name)
+	}
+	if want := []string{"cc3"}; !slices.Equal(names, want) {
+		t.Errorf("evicted %v, want %v", names, want)
+	}
+	if got, want := h.usageBytes(), int64(35); got != want {
+		t.Errorf("usage after evict = %d, want %d", got, want)
+	}
+
+	if size, ok := h.remove("bb2"); !ok || size != 25 {
+		t.Errorf("remove(bb2) = %d, %v; want 25, true", size, ok)
+	}
+	if _, ok := h.remove("bb2"); ok {
+		t.Error("second remove(bb2) reported present")
+	}
+	if got, want := h.usageBytes(), int64(10); got != want {
+		t.Errorf("usage after remove = %d, want %d", got, want)
+	}
+
+	// Promotions: rejected until the index is ready, then rejected for
+	// in-flight and resident names.
+	if h.tryStartPromotion("dd4") {
+		t.Error("tryStartPromotion(dd4) = true before ready, want false")
+	}
+	h.ready.Store(true)
+	if !h.tryStartPromotion("dd4") {
+		t.Error("tryStartPromotion(dd4) = false, want true")
+	}
+	if h.tryStartPromotion("dd4") {
+		t.Error("second tryStartPromotion(dd4) = true, want false")
+	}
+	h.endPromotion("dd4")
+	if h.tryStartPromotion("aa1") {
+		t.Error("tryStartPromotion(aa1) = true for resident entry, want false")
+	}
+}
+
+func TestSQLiteDir(t *testing.T) {
+	sqlDir := t.TempDir()
+	st := newServerTester(t, WithSQLiteDir(sqlDir))
+	c := st.mkClient()
+	st.wantPut(c, "0001", "9901", "test data")
+	st.wantGet(c, "0001", "9901", "test data")
+
+	dbName := fmt.Sprintf("gocached-v%d.db", schemaVersion)
+	if _, err := os.Stat(filepath.Join(sqlDir, dbName)); err != nil {
+		t.Errorf("DB not in sqlite dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(st.srv.dir, dbName)); !os.IsNotExist(err) {
+		t.Errorf("DB unexpectedly present in cache dir (err=%v)", err)
+	}
+}
+
+// hotFiles returns the base names of all non-temp files in the hot dir,
+// sorted.
+func (st *tester) hotFiles() []string {
+	st.t.Helper()
+	var ret []string
+	err := filepath.Walk(st.srv.hotDir, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !fi.Mode().IsRegular() || strings.HasPrefix(fi.Name(), "upload-") {
+			return nil
+		}
+		ret = append(ret, fi.Name())
+		return nil
+	})
+	if err != nil {
+		st.t.Fatalf("Walk: %v", err)
+	}
+	slices.Sort(ret)
+	return ret
+}
+
+// waitFor polls f until it returns true or the timeout expires.
+//
+// It can't use testing/synctest because these tests exercise the real HTTP
+// path via httptest over loopback, and goroutines blocked in network
+// syscalls are never durably blocked inside a synctest bubble.
+func waitFor(t testing.TB, what string, f func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if f() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for %s", what)
+}
+
+func TestTieringWriteThrough(t *testing.T) {
+	st := newServerTester(t, WithHotDir(t.TempDir()), WithHotCapacity(1<<20))
+	c := st.mkClient()
+
+	uncompressed := strings.Repeat("x", smallObjectSize+1) // stored raw
+	compressed := strings.Repeat("y", smallObjectSize+2)   // stored lz4
+	st.wantPut(c, "0001", "9901", uncompressed)
+	st.wantPut(c, "0002", "9902", compressed)
+	st.wantPut(c, "0003", "9903", "small") // inline; no disk file in either tier
+
+	cold := st.diskFiles()
+	hot := st.hotFiles()
+	if !slices.Equal(cold, hot) {
+		t.Errorf("cold files %v != hot files %v", cold, hot)
+	}
+	if len(hot) != 2 {
+		t.Fatalf("got %d files, want 2", len(hot))
+	}
+
+	var wantUsage int64
+	for _, name := range hot {
+		coldBytes, err := os.ReadFile(filepath.Join(st.srv.dir, name[:2], name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		hotBytes, err := os.ReadFile(st.srv.hotFilepath(name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(coldBytes, hotBytes) {
+			t.Errorf("tier contents differ for %v", name)
+		}
+		wantUsage += int64(len(hotBytes))
+	}
+	if got := st.srv.hot.usageBytes(); got != wantUsage {
+		t.Errorf("hot usage = %d, want %d", got, wantUsage)
+	}
+	if got := st.srv.hot.len(); got != 2 {
+		t.Errorf("hot len = %d, want 2", got)
+	}
+}
+
+func TestTieringPromotion(t *testing.T) {
+	st := newServerTester(t, WithHotDir(t.TempDir()), WithHotCapacity(1<<20))
+	c := st.mkClient()
+
+	val := strings.Repeat("x", smallObjectSize+1)
+	st.wantPut(c, "0001", "9901", val)
+
+	names := st.hotFiles()
+	if len(names) != 1 {
+		t.Fatalf("got %d hot files, want 1", len(names))
+	}
+	name := names[0]
+
+	// Simulate hot tier loss (e.g. ephemeral disk wiped) without telling the
+	// index: the next GET must recover by dropping the stale entry and
+	// promoting the blob back from the cold tier.
+	if err := os.Remove(st.srv.hotFilepath(name)); err != nil {
+		t.Fatal(err)
+	}
+
+	// GET is served from the cold tier and triggers an async promotion.
+	st.wantGet(st.mkClient(), "0001", "9901", val)
+	st.wantMetric(&st.srv.m.HotMisses, 1)
+	st.wantMetric(&st.srv.m.HotHits, 0)
+
+	waitFor(t, "promotion", func() bool {
+		return st.srv.m.HotPromotions.Value() == 1 && st.srv.hot.len() == 1
+	})
+	hotBytes, err := os.ReadFile(st.srv.hotFilepath(name))
+	if err != nil {
+		t.Fatalf("promoted file: %v", err)
+	}
+	coldBytes, err := os.ReadFile(filepath.Join(st.srv.dir, name[:2], name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(hotBytes, coldBytes) {
+		t.Error("promoted file differs from cold copy")
+	}
+
+	// The next GET is served from the hot tier.
+	st.wantGet(st.mkClient(), "0001", "9901", val)
+	st.wantMetric(&st.srv.m.HotHits, 1)
+	st.wantMetric(&st.srv.m.HotMisses, 0)
+}
+
+func TestTieringHotEviction(t *testing.T) {
+	st := newServerTester(t, WithHotDir(t.TempDir()), WithHotCapacity(1<<20))
+	c := st.mkClient()
+
+	// All blobs are exactly 1025 bytes: big enough to hit disk, small enough
+	// to stay below lz4CompressThreshold so stored size == len.
+	vals := []string{
+		strings.Repeat("a", smallObjectSize+1),
+		strings.Repeat("b", smallObjectSize+1),
+		strings.Repeat("c", smallObjectSize+1),
+		strings.Repeat("d", smallObjectSize+1),
+	}
+	blobSize := int64(smallObjectSize + 1)
+	st.wantPut(c, "0001", "9901", vals[0])
+	st.wantPut(c, "0002", "9902", vals[1])
+	st.wantPut(c, "0003", "9903", vals[2])
+	st.wantPut(c, "0004", "9904", vals[3])
+
+	// Touch the first (oldest) blob so it becomes most recently used.
+	st.wantGet(st.mkClient(), "0001", "9901", vals[0])
+	st.wantMetric(&st.srv.m.HotHits, 1)
+
+	// Lower the capacity so only the touched blob fits under the 95% target.
+	st.srv.hotCap = 2 * blobSize
+	st.srv.evictHotIfOver()
+
+	if got, want := st.srv.hot.len(), 1; got != want {
+		t.Fatalf("hot len after evict = %d, want %d", got, want)
+	}
+	if got, want := st.srv.hot.usageBytes(), blobSize; got != want {
+		t.Errorf("hot usage after evict = %d, want %d", got, want)
+	}
+	st.wantMetric(&st.srv.m.HotEvicted, 3)
+
+	// The survivor is the touched blob, still readable from the hot tier.
+	st.wantGet(st.mkClient(), "0001", "9901", vals[0])
+	st.wantMetric(&st.srv.m.HotHits, 1)
+
+	// Cold tier still has all four blobs; evicted ones are served from cold.
+	if got := len(st.diskFiles()); got != 4 {
+		t.Errorf("cold files = %d, want 4", got)
+	}
+	st.wantGet(st.mkClient(), "0004", "9904", vals[3])
+	st.wantMetric(&st.srv.m.HotMisses, 1)
+}
+
+func TestTieringMainEvictionRemovesBothTiers(t *testing.T) {
+	st := newServerTester(t, WithHotDir(t.TempDir()), WithHotCapacity(1<<20))
+	st.srv.maxAge = 24 * time.Hour
+	c := st.mkClient()
+
+	st.wantPut(c, "0001", "9901", strings.Repeat("x", smallObjectSize+1))
+	st.advanceClock(25 * time.Hour)
+	st.wantPut(c, "0002", "9902", strings.Repeat("y", smallObjectSize+1))
+
+	if got := st.srv.hot.len(); got != 2 {
+		t.Fatalf("hot len = %d, want 2", got)
+	}
+
+	clean := st.cleanOldObjects()
+	if clean.Count != 1 {
+		t.Fatalf("cleaned %v, want Count 1", clean)
+	}
+
+	cold := st.diskFiles()
+	hot := st.hotFiles()
+	if len(cold) != 1 || !slices.Equal(cold, hot) {
+		t.Errorf("after eviction cold = %v, hot = %v; want the same single file", cold, hot)
+	}
+	if got, want := st.srv.hot.usageBytes(), int64(smallObjectSize+1); got != want {
+		t.Errorf("hot usage = %d, want %d", got, want)
+	}
+}
+
+// TestTieringNotReady exercises the window before the async startup scan has
+// completed: reads are served from existing hot files, but nothing new is
+// written into the hot tier.
+func TestTieringNotReady(t *testing.T) {
+	st := newServerTester(t, WithHotDir(t.TempDir()), WithHotCapacity(1<<20))
+	c := st.mkClient()
+
+	val := strings.Repeat("a", smallObjectSize+1)
+	st.wantPut(c, "0001", "9901", val)
+	names := st.hotFiles()
+	if len(names) != 1 {
+		t.Fatalf("got %d hot files, want 1", len(names))
+	}
+
+	// Rewind to the not-ready state, as if the scan were still running.
+	st.srv.hot.ready.Store(false)
+
+	// Existing hot files are still served.
+	st.wantGet(st.mkClient(), "0001", "9901", val)
+	st.wantMetric(&st.srv.m.HotHits, 1)
+
+	// New PUTs skip the hot tier.
+	val2 := strings.Repeat("b", smallObjectSize+1)
+	st.wantPut(c, "0002", "9902", val2)
+	if got := st.hotFiles(); len(got) != 1 {
+		t.Errorf("hot files after not-ready PUT = %v, want just the original", got)
+	}
+
+	// GETs served from cold don't start promotions. tryStartPromotion
+	// rejects synchronously when not ready, so no goroutine to wait on.
+	st.wantGet(st.mkClient(), "0002", "9902", val2)
+	st.wantMetric(&st.srv.m.HotMisses, 1)
+	st.wantMetric(&st.srv.m.HotPromotions, 0)
+	if got := st.hotFiles(); len(got) != 1 {
+		t.Errorf("hot files after not-ready GET = %v, want just the original", got)
+	}
+
+	// Once ready again, the same GET promotes.
+	st.srv.hot.ready.Store(true)
+	st.wantGet(st.mkClient(), "0002", "9902", val2)
+	waitFor(t, "promotion", func() bool { return st.srv.m.HotPromotions.Value() == 1 })
+	if got := st.hotFiles(); len(got) != 2 {
+		t.Errorf("hot files after ready GET = %v, want 2", got)
+	}
+}
+
+func TestHotStartupScan(t *testing.T) {
+	hotDir := t.TempDir()
+
+	writeHotFile := func(name string, size int, age time.Duration) {
+		t.Helper()
+		dir := filepath.Join(hotDir, name[:2])
+		if err := os.MkdirAll(dir, 0750); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, bytes.Repeat([]byte{'x'}, size), 0644); err != nil {
+			t.Fatal(err)
+		}
+		mtime := time.Now().Add(-age)
+		if err := os.Chtimes(path, mtime, mtime); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeHotFile("aa11", 10, 3*time.Hour) // oldest
+	writeHotFile("bb22", 20, 2*time.Hour)
+	writeHotFile("cc33", 30, 1*time.Hour) // newest
+
+	// A stale temp file is deleted by the scan; a fresh one is left alone.
+	// writeDiskBlob and promoteToHot create their temp files at the hot dir
+	// root, so that's where the scan looks for leftovers.
+	writeTemp := func(name string, age time.Duration) {
+		t.Helper()
+		path := filepath.Join(hotDir, name)
+		if err := os.WriteFile(path, []byte("tmp"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		mtime := time.Now().Add(-age)
+		if err := os.Chtimes(path, mtime, mtime); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeTemp("upload-1-stale", 2*time.Hour)
+	writeTemp("upload-2-fresh", 0)
+
+	st := newServerTester(t, WithHotDir(hotDir), WithHotCapacity(1<<20))
+
+	if got, want := st.srv.hot.usageBytes(), int64(60); got != want {
+		t.Errorf("usage = %d, want %d", got, want)
+	}
+	if got, want := st.srv.hot.len(), 3; got != want {
+		t.Errorf("len = %d, want %d", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(hotDir, "upload-1-stale")); !os.IsNotExist(err) {
+		t.Errorf("stale temp not removed (err=%v)", err)
+	}
+	if _, err := os.Stat(filepath.Join(hotDir, "upload-2-fresh")); err != nil {
+		t.Errorf("fresh temp unexpectedly removed: %v", err)
+	}
+
+	// Eviction removes the files with the oldest mtimes first: aa11 and bb22
+	// go, bringing usage from 60 to 30, at the 95% target of the 32-byte cap.
+	st.srv.hotCap = 32
+	st.srv.evictHotIfOver()
+	if got, want := st.hotFiles(), []string{"cc33"}; !slices.Equal(got, want) {
+		t.Errorf("hot files after evict = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Our AWS cache instance stores everything on its ephemeral NVMe disk, so
the whole cache is lost on every reboot and its size is capped by the
local disk. Let the blob directory live on a big slow filesystem (an S3
Files NFS mount) as the source of truth, with a new optional --hot-dir
flag naming a fast local tier (NVMe) holding a bounded copy of recently
used blobs, capped by --hot-capacity-gb. The new --sqlite-dir flag lets
the metadata database live on its own volume (EBS), defaulting to the
blob directory as before.

PUTs write through to both tiers in one pass; a hot tier failure never
fails the PUT since a later GET re-promotes. GETs try the hot tier
first and asynchronously promote cold hits into it. The hot tier is
tracked by an in-memory LRU index seeded from an mtime-ordered scan at
startup, evicting least recently used files down to 95% of capacity;
hot files are disposable copies, so eviction and reboot loss are always
safe. When tiering is not enabled, behavior is unchanged.

Updates tailscale/corp#44699
