### PR TITLE
gocached: do both PUT metadata inserts in one SQLite transaction

### DIFF
--- a/gocached/gocached.go
+++ b/gocached/gocached.go
@@ -1651,8 +1651,19 @@ func (s *Server) handlePut(w http.ResponseWriter, r *http.Request, stats *stats,
 	s.sqliteWriteMu.Lock()
 	defer s.sqliteWriteMu.Unlock()
 
+	// Do both inserts in one transaction so each PUT pays for a single
+	// WAL commit (and its fsync) rather than two autocommits.
+	tx, err := s.db.Begin()
+	if err != nil {
+		s.logf("Begin tx error: %v", err)
+		stats.PutErrs++
+		http.Error(w, "Begin tx error", http.StatusInternalServerError)
+		return
+	}
+	defer tx.Rollback()
+
 	var blobID int64
-	err := s.db.QueryRow(`INSERT INTO Blobs (SHA256, StoredSize, UncompressedSize, SmallData)
+	err = tx.QueryRow(`INSERT INTO Blobs (SHA256, StoredSize, UncompressedSize, SmallData)
 		VALUES (?, ?, ?, ?)
 		ON CONFLICT(SHA256) DO UPDATE SET SHA256=excluded.SHA256
 		RETURNING BlobID;
@@ -1670,7 +1681,7 @@ func (s *Server) handlePut(w http.ResponseWriter, r *http.Request, stats *stats,
 	if sha256hex != outputID {
 		altObjectID = outputID
 	}
-	res, err := s.db.Exec(`INSERT OR IGNORE INTO Actions (NamespaceID, ActionID, BlobID, AltOutputID, CreateTime, AccessTime)
+	res, err := tx.Exec(`INSERT OR IGNORE INTO Actions (NamespaceID, ActionID, BlobID, AltOutputID, CreateTime, AccessTime)
 	VALUES (?, ?, ?, ?, ?, ?)`,
 		namespaceID,
 		actionID,
@@ -1691,6 +1702,13 @@ func (s *Server) handlePut(w http.ResponseWriter, r *http.Request, stats *stats,
 		s.logf("Actions rows affected error: %v", err)
 		stats.PutErrs++
 		http.Error(w, "Actions rows affected error", http.StatusInternalServerError)
+		return
+	}
+
+	if err := tx.Commit(); err != nil {
+		s.logf("Commit tx error: %v", err)
+		stats.PutErrs++
+		http.Error(w, "Commit tx error", http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
After deploying storage tiering to the AWS CI cache instance
(tailscale/corp#44699), the instance showed a sustained ~11 MB/s and
~1400 IOPS of writes to the EBS volume holding the SQLite database,
roughly 200x the logical metadata growth rate, and PUT latency
averaged 3.6 seconds with ~520 PUTs in flight against a throughput
ceiling of ~115 PUTs/sec.

The cause: each PUT held sqliteWriteMu across two separate autocommit
statements (the Blobs insert and the Actions insert), paying two WAL
commits and two fsyncs per PUT. At a few milliseconds per fsync, that
serialized writer capped throughput at almost exactly the observed
rate; everything beyond it was queueing.

Wrap the two inserts in a single explicit transaction so each PUT
pays for one WAL commit instead of two, roughly halving the writer's
per-PUT hold time and doubling the metadata throughput ceiling. Also
only update the in-memory usage deltas after the transaction commits,
so a failed commit can no longer skew the usage accounting.

This is a stopgap; the longer term plan is to queue PUT metadata in
memory (serving GETs from it) and batch the SQLite writes
asynchronously, coalescing hot B-tree pages across many PUTs.

Updates tailscale/corp#44699
