### PR TITLE
cachers,cmd/go-cacher: add stats and variable timeouts for async PUTs

### DIFF
--- a/cachers/http.go
+++ b/cachers/http.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pierrec/lz4/v4"
@@ -49,16 +50,20 @@ type HTTPClient struct {
 	// as the blob is on local disk, and the upload happens in a background goroutine.
 	BestEffortHTTP bool
 
-	// AsyncPutTimeout, if non-zero, bounds how long a background PUT may run
-	// before its context is cancelled. It only applies when BestEffortHTTP is set.
-	AsyncPutTimeout time.Duration
+	// AsyncPutTimeout, if non-nil, returns how long a background PUT of the
+	// given object size can run before its context is canceled. A zero or
+	// negative duration means no timeout. It only applies when BestEffortHTTP
+	// is set.
+	AsyncPutTimeout func(size int64) time.Duration
 
 	// AsyncPutMaxConcurrent, if positive, caps the number of background PUTs
 	// running at once. New PUTs beyond the cap are queued until an existing PUT
-	// finishes. If Close is called while some background PUTs are in-progress, it
-	// will wait for up to AsyncPutTimeout before forcing shutdown. Disk writes
-	// are not affected, and it only applies when BestEffortHTTP is set.
+	// finishes. Disk writes are not affected, and it only applies when
+	// BestEffortHTTP is set.
 	AsyncPutMaxConcurrent int
+
+	PutsTimedOut atomic.Int64 // The number of PUTs that timed out.
+	PutsCanceled atomic.Int64 // The number of PUTs canceled due to shutdown.
 
 	asyncOnce   sync.Once
 	asyncPutSem chan struct{}
@@ -90,28 +95,23 @@ func (c *HTTPClient) asyncPutContext() context.Context {
 	return c.baseCtx
 }
 
-// Shutdown blocks until all background PUTs have finished or AsyncPutTimeout
-// elapses, whichever comes first. If AsyncPutTimeout is zero (unbounded
-// PUTs), Shutdown waits indefinitely. It reports whether all PUTs drained in
-// time.
-func (c *HTTPClient) Shutdown() (drained bool) {
+// Shutdown blocks until all background PUTs have finished or ctx is done,
+// whichever comes first. When ctx is done first, it cancels the context shared
+// by any still-running PUTs and waits for them to unwind, so no background PUT
+// outlives Shutdown. It reports whether all PUTs drained before ctx was done.
+func (c *HTTPClient) Shutdown(ctx context.Context) (drained bool) {
 	done := make(chan struct{})
 	go func() {
 		c.inFlightWG.Wait()
 		close(done)
 	}()
-	if c.AsyncPutTimeout == 0 {
-		<-done
-		return true
-	}
-	t := time.NewTimer(c.AsyncPutTimeout)
-	defer t.Stop()
 	select {
 	case <-done:
 		return true
-	case <-t.C:
+	case <-ctx.Done():
 		c.ensureAsyncSetup()
 		c.baseCancel()
+		<-done
 		return false
 	}
 }
@@ -290,6 +290,7 @@ func (c *HTTPClient) Put(ctx context.Context, actionID, outputID string, size in
 				select {
 				case sem <- struct{}{}:
 				case <-putCtx.Done():
+					c.PutsCanceled.Add(1)
 					return
 				}
 				defer func() {
@@ -320,10 +321,22 @@ func (c *HTTPClient) Put(ctx context.Context, actionID, outputID string, size in
 
 func (c *HTTPClient) putRemote(ctx context.Context, actionID, outputID string, size int64, body io.ReadCloser) error {
 	defer body.Close()
-	if c.BestEffortHTTP && c.AsyncPutTimeout != 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, c.AsyncPutTimeout)
-		defer cancel()
+	if c.BestEffortHTTP && c.AsyncPutTimeout != nil {
+		if d := c.AsyncPutTimeout(size); d > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, d)
+			defer cancel()
+		}
+	}
+	if c.BestEffortHTTP {
+		defer func() {
+			switch {
+			case c.baseCtx.Err() != nil:
+				c.PutsCanceled.Add(1)
+			case ctx.Err() != nil:
+				c.PutsTimedOut.Add(1)
+			}
+		}()
 	}
 	// For a zero-length body, hand net/http NoBody so it sends an explicit
 	// Content-Length: 0 rather than switching to chunked transfer encoding,

--- a/cachers/http_test.go
+++ b/cachers/http_test.go
@@ -275,11 +275,10 @@ func TestHTTPClientShutdownDrains(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		tr := newBlockingPutTransport()
 		hc := &HTTPClient{
-			BaseURL:         "http://fake",
-			Disk:            &DiskCache{Dir: t.TempDir()},
-			HTTPClient:      &http.Client{Transport: tr},
-			BestEffortHTTP:  true,
-			AsyncPutTimeout: 2 * time.Second,
+			BaseURL:        "http://fake",
+			Disk:           &DiskCache{Dir: t.TempDir()},
+			HTTPClient:     &http.Client{Transport: tr},
+			BestEffortHTTP: true,
 		}
 
 		data := []byte("some cached output")
@@ -293,7 +292,9 @@ func TestHTTPClientShutdownDrains(t *testing.T) {
 
 		shutdownReturned := make(chan bool, 1)
 		go func() {
-			shutdownReturned <- hc.Shutdown()
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			shutdownReturned <- hc.Shutdown(ctx)
 		}()
 
 		// With the upload still blocked, Shutdown must not return.
@@ -325,11 +326,10 @@ func TestHTTPClientShutdownCancelsStragglers(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		tr := newBlockingPutTransport() // never released
 		hc := &HTTPClient{
-			BaseURL:         "http://fake",
-			Disk:            &DiskCache{Dir: t.TempDir()},
-			HTTPClient:      &http.Client{Transport: tr},
-			BestEffortHTTP:  true,
-			AsyncPutTimeout: 2 * time.Second,
+			BaseURL:        "http://fake",
+			Disk:           &DiskCache{Dir: t.TempDir()},
+			HTTPClient:     &http.Client{Transport: tr},
+			BestEffortHTTP: true,
 		}
 
 		data := []byte("some cached output")
@@ -343,13 +343,62 @@ func TestHTTPClientShutdownCancelsStragglers(t *testing.T) {
 
 		// The upload never unblocks, so Shutdown must hit its deadline, cancel
 		// the shared context, and report that it did not drain.
-		if drained := hc.Shutdown(); drained {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if drained := hc.Shutdown(ctx); drained {
 			t.Error("Shutdown returned drained=true, want false")
 		}
 
-		// Cancelling the shared context unblocks the straggler, so the
+		// Canceling the shared context unblocks the straggler, so the
 		// background goroutine exits rather than leaking.
 		synctest.Wait()
+		if got := hc.PutsCanceled.Load(); got != 1 {
+			t.Errorf("PutsCanceled = %d, want 1", got)
+		}
+		if got := hc.PutsTimedOut.Load(); got != 0 {
+			t.Errorf("PutsTimedOut = %d, want 0", got)
+		}
+	})
+}
+
+// TestHTTPClientAsyncPutTimeout verifies that AsyncPutTimeout is applied per
+// object size and that a PUT canceled by its own timeout is counted by
+// PutsTimedOut.
+func TestHTTPClientAsyncPutTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		tr := newBlockingPutTransport() // never released
+		var gotSize int64
+		hc := &HTTPClient{
+			BaseURL:        "http://fake",
+			Disk:           &DiskCache{Dir: t.TempDir()},
+			HTTPClient:     &http.Client{Transport: tr},
+			BestEffortHTTP: true,
+			AsyncPutTimeout: func(size int64) time.Duration {
+				gotSize = size
+				return time.Second
+			},
+		}
+
+		data := []byte("some cached output")
+		if _, err := hc.Put(t.Context(), "aabbccdd", "eeff0011", int64(len(data)), bytes.NewReader(data)); err != nil {
+			t.Fatalf("Put returned error: %v", err)
+		}
+
+		// The upload never unblocks, so its own timeout must fire and count it
+		// as timed out without any call to Shutdown. Sleeping past the timeout
+		// durably blocks this goroutine so the bubble's fake clock advances and
+		// the 1s timer fires.
+		time.Sleep(2 * time.Second)
+		synctest.Wait()
+		if gotSize != int64(len(data)) {
+			t.Errorf("AsyncPutTimeout called with size %d, want %d", gotSize, len(data))
+		}
+		if got := hc.PutsTimedOut.Load(); got != 1 {
+			t.Errorf("PutsTimedOut = %d, want 1", got)
+		}
+		if got := hc.PutsCanceled.Load(); got != 0 {
+			t.Errorf("PutsCanceled = %d, want 0", got)
+		}
 	})
 }
 

--- a/cmd/go-cacher/cacher.go
+++ b/cmd/go-cacher/cacher.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -20,6 +21,10 @@ import (
 	"github.com/bradfitz/go-tool-cache/cacheproc"
 	"github.com/bradfitz/go-tool-cache/cachers"
 )
+
+// shutdownDrainTimeout bounds how long Close waits for background PUTs to drain
+// before abandoning them.
+const shutdownDrainTimeout = 5 * time.Second
 
 var (
 	dir        = flag.String("cache-dir", "", "cache directory; empty means automatic")
@@ -54,10 +59,15 @@ func main() {
 		Get: dc.Get,
 		Put: dc.Put,
 	}
+	var hc *cachers.HTTPClient
 	statsFunc := func() error {
 		if *verbose {
-			log.Printf("cacher: closing; %d gets (%d hits, %d misses, %d errors); %d puts (%d errors)",
-				p.Gets.Load(), p.GetHits.Load(), p.GetMisses.Load(), p.GetErrors.Load(), p.Puts.Load(), p.PutErrors.Load())
+			putDetail := fmt.Sprintf("%d errors", p.PutErrors.Load())
+			if hc != nil {
+				putDetail += fmt.Sprintf(", %d timed out, %d canceled", hc.PutsTimedOut.Load(), hc.PutsCanceled.Load())
+			}
+			log.Printf("cacher: closing; %d gets (%d hits, %d misses, %d errors); %d puts (%s)",
+				p.Gets.Load(), p.GetHits.Load(), p.GetMisses.Load(), p.GetErrors.Load(), p.Puts.Load(), putDetail)
 		}
 		return nil
 	}
@@ -82,7 +92,7 @@ func main() {
 	}
 
 	if *serverBase != "" {
-		hc := &cachers.HTTPClient{
+		hc = &cachers.HTTPClient{
 			BaseURL:     *serverBase,
 			Disk:        dc,
 			Verbose:     *verbose,
@@ -91,8 +101,14 @@ func main() {
 		p.Get = hc.Get
 		p.Put = hc.Put
 		p.Close = func() error {
-			if !hc.Shutdown() {
+			ctx, cancel := context.WithTimeout(context.Background(), shutdownDrainTimeout)
+			defer cancel()
+			if !hc.Shutdown(ctx) {
 				log.Printf("go-cacher: timed out waiting for background PUTs to drain")
+			}
+			// Always surface dropped PUTs; the full stats line below is verbose-only.
+			if timedOut, canceled := hc.PutsTimedOut.Load(), hc.PutsCanceled.Load(); timedOut+canceled > 0 {
+				log.Printf("go-cacher: %d background PUTs timed out, %d canceled", timedOut, canceled)
 			}
 			return statsFunc()
 		}


### PR DESCRIPTION
A few minor follow-ups to #40 to improve the API and observability:

* Allow callers to use different timeouts for different object sizes.
* Track stats of how many async PUTs are cancelled/timed out.
* Add a ctx to Shutdown's args for better separation of timeout vs shutdown behaviour.

Updates tailscale/corp#45334